### PR TITLE
Alarms customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,22 @@ netdata_git_repo: 'https://github.com/firehol/netdata.git'
 # Defines whether Netdata health is enabled
 netdata_health_enabled: true
 
+# Defines if Netdata health alarms should be configured
+netdata_alarm_configure: false
+
+# Defines location of Netdata health_alarm_notify.conf
+netdata_alarm_config_file: /etc/netdata/health_alarm_notify.conf
+
+# Define configuration for health_alarm_notify.conf.
+# Example:
+# netdata_health_alarm_notify_configs:
+#   https_proxy: http://localhost:3128
+#   SLACK_WEBHOOK_URL: https://hooks.slack.com/...
+netdata_alarm_notify_configs: {}
+
+# Defines path to alarm-notify.sh
+netdata_health_alarm_script: /usr/libexec/netdata/plugins.d/alarm-notify.sh
+
 # The number of entries the netdata daemon will by default keep in memory
 # for each chart dimension.
 netdata_history: '3996'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -55,6 +55,22 @@ netdata_git_repo: 'https://github.com/firehol/netdata.git'
 # Defines whether Netdata health is enabled
 netdata_health_enabled: true
 
+# Defines if Netdata health alarms should be configured
+netdata_alarm_configure: false
+
+# Defines location of Netdata health_alarm_notify.conf
+netdata_alarm_config_file: /etc/netdata/health_alarm_notify.conf
+
+# Define configuration for health_alarm_notify.conf.
+# Example:
+# netdata_health_alarm_notify_configs:
+#   https_proxy: http://localhost:3128
+#   SLACK_WEBHOOK_URL: https://hooks.slack.com/...
+netdata_alarm_notify_configs: {}
+
+# Defines path to alarm-notify.sh
+netdata_health_alarm_script: /usr/libexec/netdata/plugins.d/alarm-notify.sh
+
 # The number of entries the netdata daemon will by default keep in memory
 # for each chart dimension.
 netdata_history: '3996'

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -9,6 +9,18 @@
   notify: "restart netdata"
   become: true
 
+- name: config | Configuring Netdata Alarm Notifications
+  blockinfile:
+    marker: "# {mark} ANSIBLE MANAGED BLOCK"
+    path: "{{ netdata_alarm_config_file }}"
+    content: |
+      {% for key in netdata_alarm_notify_configs %}
+      {{ key }}="{{ netdata_alarm_notify_configs[key] }}"
+      {% endfor %}
+  notify: "restart netdata"
+  become: true
+  when: netdata_alarm_configure
+
 - name: config | Configuring Netdata streaming
   template:
     src: "stream.conf.j2"

--- a/templates/netdata.conf.j2
+++ b/templates/netdata.conf.j2
@@ -71,7 +71,7 @@
   enabled = yes
 {% endif %}
 	# in memory max health log entries = 1000
-	script to execute on alarm = /usr/libexec/netdata/plugins.d/alarm-notify.sh
+	script to execute on alarm = {{ netdata_health_alarm_script }}
 	health configuration directory = /etc/netdata/health.d
 	# run at least every seconds = 10
 	# postpone alarms during hibernation for seconds = 60


### PR DESCRIPTION
* allow for custom alarm-notify file
* allow for customization of health alarms.

Since health_alarm_notify.conf is a bash source file, it seemed less invasive to simply put the customizations and overrides at the end of the file. That way, we don't have to ship our own copy of what upstream provides.