### PR TITLE
Resolved Ubuntu 18.04 install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,9 @@ env:
   # - distribution: fedora
   #   init:        /usr/lib/systemd/systemd
   #   version:     24
-  # - distribution: ubuntu
-  #   init:        /lib/systemd/systemd
-  #   version:     bionic
+  - distribution: ubuntu
+    init:        /lib/systemd/systemd
+    version:     bionic
   - distribution: ubuntu
     init:        /lib/systemd/systemd
     version:     xenial

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -33,7 +33,6 @@ netdata_debian_pre_reqs:
   - curl
   - gcc
   - git
-  - iproute
   - libmnl-dev
   - libmnl0
   - libuuid1

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -5,3 +5,12 @@
     state: present
   become: true
   with_items: "{{ netdata_debian_pre_reqs }}"
+
+- name: debian | Installing iproute Package
+  apt:
+    name: iproute
+    state: present
+  become: true
+  when: >
+        not ansible_distribution == "Ubuntu" and
+        ansible_distribution_version is version('18.04', '<', strict=True)


### PR DESCRIPTION
This resolves #12

The iproute package no longer exists in Ubuntu 18.04 default
installation so we needed to exclude installing this package only on
Ubuntu 18.04+.