### PR TITLE
Added support for specifying master node port for streaming.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -134,7 +134,7 @@ netdata_stream_config_file: /etc/netdata/stream.conf
 # Defines Netdata API Key (must be generated with command uuidgen)
 netdata_stream_api_key: 11111111-2222-3333-4444-555555555555
 
-# Defines Netdata master node
+# Defines Netdata master node and port (e.g. 127.0.0.1:19999)
 netdata_stream_master_node: ""
 
 # Defines if Netdata should be uninstalled

--- a/templates/stream.conf.j2
+++ b/templates/stream.conf.j2
@@ -20,7 +20,7 @@
     enabled = yes
       
     # the IP and PORT of the master
-    destination = {{ netdata_stream_master_node }}:{{ netdata_default_port }}
+    destination = {{ netdata_stream_master_node }}
   
     # the API key to use
     api key = {{ netdata_stream_api_key }}


### PR DESCRIPTION
This PR simply removes the usage of `netdata_default_port` in the streaming configuration template so that the master node port can be directly specified inside the `netdata_stream_master_node` variable while keeping the generated streaming configuration valid (another option would have been to add a new variable for the master node port, but we found it less straightforward).

Without this change there is no mean of getting a valid streaming configuration with a master node port different than the default one.