### PR TITLE
Allow hostname customisation

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -71,6 +71,8 @@ netdata_alarm_notify_configs: {}
 # Defines path to alarm-notify.sh
 netdata_health_alarm_script: /usr/libexec/netdata/plugins.d/alarm-notify.sh
 
+# The host name displayed in netdata
+netdata_hostname: "{{ ansible_hostname }}"
 # The number of entries the netdata daemon will by default keep in memory
 # for each chart dimension.
 netdata_history: 3996

--- a/templates/netdata.conf.j2
+++ b/templates/netdata.conf.j2
@@ -4,7 +4,7 @@
 [global]
 	# glibc malloc arena max for plugins = 1
 	# glibc malloc arena max for netdata = 1
-	hostname = {{ ansible_hostname }}
+	hostname = {{ netdata_hostname }}
 	history = {{ netdata_history }}
 	update every = {{ netdata_update_every }}
 	config directory = /etc/netdata


### PR DESCRIPTION
This PR allows to customize hostname given to netdata. Default is kept to `ansible_hostname`