### PR TITLE
Allow restart on failure

### DIFF
--- a/templates/etc/systemd/system/netdata.service.j2
+++ b/templates/etc/systemd/system/netdata.service.j2
@@ -7,6 +7,7 @@ Type=simple
 User={{ netdata_user_info['user'] }}
 Group={{ netdata_user_info['group'] }}
 ExecStart=/usr/sbin/netdata -D
+Restart=on-failure
 
 # saving a big db on slow disks may need some time
 TimeoutStopSec=60


### PR DESCRIPTION
This will cause the service to restart if it gets shut down uncleanly. It will wait 30 seconds between restart attempts