### PR TITLE
Fix alarm configuration failing when file doesn't exists

### DIFF
--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -13,6 +13,7 @@
   blockinfile:
     marker: "# {mark} ANSIBLE MANAGED BLOCK"
     path: "{{ netdata_alarm_config_file }}"
+    create: yes
     content: |
       {% for key in netdata_alarm_notify_configs %}
       {{ key }}="{{ netdata_alarm_notify_configs[key] }}"


### PR DESCRIPTION
if `netdata_alarm_config_file` does not exist task will fail. This PR adds `create: yes` to blockinfile options and fixes it