### PR TITLE
Updating netdata git url to fix #23

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -50,7 +50,7 @@ netdata_debian_pre_reqs:
   - zlib1g-dev
 
 # Defines the Git repo to pull down for installs
-netdata_git_repo: https://github.com/firehol/netdata.git
+netdata_git_repo: https://github.com/netdata/netdata.git
 
 # Defines whether Netdata health is enabled
 netdata_health_enabled: true


### PR DESCRIPTION
Netdata changed git URLs. This broke auto updating. Uninstalling netdata and reinstalling with the correct URL addresses this.

This pull fixes #23