### PR TITLE
[BUGFIX] Notifications are not sent

### DIFF
--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -14,6 +14,8 @@
     marker: "# {mark} ANSIBLE MANAGED BLOCK"
     path: "{{ netdata_alarm_config_file }}"
     create: yes
+    owner: "{{ netdata_user_info['user'] }}"
+    group: root
     content: |
       {% for key in netdata_alarm_notify_configs %}
       {{ key }}="{{ netdata_alarm_notify_configs[key] }}"


### PR DESCRIPTION
Missing permissions on /etc/netdata/health_alarm_notify.conf file.

It prevents configuraiton file to be read and notifications to be sent.

Thanks a lot for your project.