### PR TITLE
Make web mode configurable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -88,6 +88,13 @@ netdata_installer: ./netdata-installer.sh
 # will be lost when netdata exits.
 netdata_memory_mode: save
 
+# Defines the mode the web-server will run in
+# static-threaded is a web server with a fix (configured number of threads)
+# single-threaded is a simple web server running with a single thread
+# multi-threaded is a web server that spawns a thread for each client connection
+# none will disable the web-server and the API
+netdata_web_mode: multi-threaded
+
 # The default port to listen for web clients.
 netdata_default_port: 19999
 

--- a/templates/netdata.conf.j2
+++ b/templates/netdata.conf.j2
@@ -36,7 +36,7 @@
 [web]
 	# web files owner = netdata
 	# web files group = netdata
-	# mode = multi-threaded
+	mode = {{ netdata_web_mode }}
 	# listen backlog = 4096
 	default port = {{ netdata_default_port }}
 	bind to = {{ netdata_bind_to|join(' ') }}


### PR DESCRIPTION
This adds a variable `netdata_web_mode` that is used to set the `web.mode`. I have a swarm of headless collectors ([link](https://docs.netdata.cloud/streaming/)) which stream to a central monitoring node, and I needed to set both `web.mode` and `memory.mode` to `none`.

The meaning of the options were taken from [here](https://github.com/netdata/netdata/tree/master/web/server).