### PR TITLE
Don't use a loop for installing pre-requisites

### DIFF
--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -1,10 +1,9 @@
 ---
 - name: debian | Installing Pre-Reqs
   apt:
-    name: "{{ item }}"
+    name: "{{ netdata_debian_pre_reqs }}"
     state: present
   become: true
-  with_items: "{{ netdata_debian_pre_reqs }}"
 
 - name: debian | Installing iproute Package
   apt:

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -1,8 +1,7 @@
 ---
 - name: redhat | Installing Pre-Reqs
   yum:
-    name: "{{ item }}"
+    name: "{{ netdata_redhat_pre_reqs }}"
     state: present
   become: true
-  with_items: "{{ netdata_redhat_pre_reqs }}"
   when: ansible_distribution != "Fedora"


### PR DESCRIPTION
Both [yum](https://docs.ansible.com/ansible/latest/modules/yum_module.html#notes) and [apt](https://docs.ansible.com/ansible/latest/modules/apt_module.html#notes) modules now support passing a list in the name parameter, instead of looping through installing each package. This speeds up the installation as well as removes the pesky warnings -

```
[DEPRECATION WARNING]: Invoking "apt" only once while using a loop via 
squash_actions is deprecated. Instead of using a loop to supply multiple items 
and specifying `name: "{{ item }}"`, please use `name: '{{ 
netdata_debian_pre_reqs }}'` and remove the loop. This feature will be removed 
in version 2.11. Deprecation warnings can be disabled by setting 
deprecation_warnings=False in ansible.cfg.
```