### PR TITLE
Fix for version check logic. did not work on Debian stretch.

### DIFF
--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -12,5 +12,4 @@
     state: present
   become: true
   when: >
-        not ansible_distribution == "Ubuntu" and
-        ansible_distribution_version is version('18.04', '<', strict=True)
+        not ansible_distribution == "Ubuntu" or (ansible_distribution == "Ubuntu" and ansible_distribution_version is version('18.04', '<', strict=True))


### PR DESCRIPTION
Hi there,

I think there was a slight error in the version check for Ubuntu, broke for me on Debian stretch. This works.