### PR TITLE
auto-udpate: since Netdata v1.11 the auto-updater cron is automatic

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,8 +1,8 @@
 ---
 # defaults file for ansible-netdata
 
-# Defines info about enabling/scheduling auto updates for Netdata version
-# https://github.com/firehol/netdata/wiki/Installation#auto-update
+# Adds installer flag to enable auto updates
+# https://docs.netdata.cloud/packaging/installer/update/#auto-update
 netdata_auto_updates:
   enabled: true
   day: "*"
@@ -10,6 +10,7 @@ netdata_auto_updates:
   minute: 0
   user: root
   weekday: "*"
+  clean_legacy_cron: true
 
 # The IP address and port to listen to. This is a space separated list of
 # IPv4 or IPv6 address and ports. The default will bind to all IP addresses

--- a/tasks/auto_updates.yml
+++ b/tasks/auto_updates.yml
@@ -1,4 +1,6 @@
 ---
+# Since netdata 1.11 the auto-updater installs the cron by itself
+# This is a legacy when Netdata didn't handle the cron itself
 - name: auto_updates | Setting Up Cron Job For Auto Updates
   cron:
     name: Netdata Auto Updates
@@ -8,4 +10,5 @@
     user: "{{ netdata_auto_updates['user'] }}"
     job: "{{ netdata_source_dir }}/{{ netdata_updater|basename }}"
     cron_file: netdata_auto_updates
+    state: "{{ netdata_auto_updates['clean_legacy_cron']|ternary('absent', 'present') }}"
   become: true

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,4 +1,7 @@
 ---
+- set_fact:
+    auto_update_cli_option: "{{ netdata_auto_updates['enabled']|ternary('--auto-update', '') }}"
+
 - name: install | Cloning {{ netdata_git_repo }} to {{ netdata_source_dir }}
   git:
     repo: "{{ netdata_git_repo }}"
@@ -7,7 +10,12 @@
   become: true
 
 - name: install | Installing Netdata ({{ netdata_installer }}) From {{ netdata_source_dir }}
-  command: "{{ netdata_installer }} --dont-wait"
+  command: "{{ installer_cli|join(' ') }}"
+  vars:
+    installer_cli:
+      - "{{ netdata_installer }}"
+      - "{{ auto_update_cli_option }}"
+      - "--dont-wait"
   args:
     chdir: "{{ netdata_source_dir }}"
     creates: /usr/sbin/netdata

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,7 +13,7 @@
   when: netdata_config
 
 - include: update.yml
-  when: netdata_update
+  when: netdata_update or netdata_update_force
 
 - include: auto_updates.yml
   when: netdata_auto_updates['enabled']


### PR DESCRIPTION
Netdata v1.11 now installs the cron by itself and the installer takes
an `--auto-update` option to install the updater script.