### PR TITLE
auto-update: don't break existing configurations

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,6 +10,10 @@ netdata_auto_updates:
   minute: 0
   user: root
   weekday: "*"
+  # WARNING: when you set this variable to 'true' and are migrating from an old version
+  # of Netdata (< v1.11.0) then the cron will be removed from your system.
+  # You will then need to launch the netdata installer manually to make sure
+  # netdata installs the cron by itself with: `./netdata-installer.sh --auto-update`
   clean_legacy_cron: true
 
 # The IP address and port to listen to. This is a space separated list of

--- a/tasks/auto_updates.yml
+++ b/tasks/auto_updates.yml
@@ -10,5 +10,5 @@
     user: "{{ netdata_auto_updates['user'] }}"
     job: "{{ netdata_source_dir }}/{{ netdata_updater|basename }}"
     cron_file: netdata_auto_updates
-    state: "{{ netdata_auto_updates['clean_legacy_cron']|ternary('absent', 'present') }}"
+    state: "{{ netdata_auto_updates['clean_legacy_cron']|default(false)|ternary('absent', 'present') }}"
   become: true


### PR DESCRIPTION
Since #33, we could break existing ansible configuration if you don't explicitly set the new `clean_legacy_cron` field. With this patch we ensure that existing config will continue to work to same way they used to without breaking changes.