### PR TITLE
Feature: a netdata host can be defined as a proxy for streaming

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -156,11 +156,16 @@ netdata_stream_enabled: false
 # Defines location of Netdata stream configuration file
 netdata_stream_config_file: /etc/netdata/stream.conf
 
-# Defines Netdata API Key (must be generated with command uuidgen)
+# Defines Netdata API Keys (must be generated with command uuidgen)
 netdata_stream_api_key: 11111111-2222-3333-4444-555555555555
+netdata_stream_send_api_key: "{{ netdata_stream_api_key }}"
+netdata_stream_receive_api_key: "{{ netdata_stream_api_key }}"
 
 # Defines Netdata master node and port (e.g. 127.0.0.1:19999)
 netdata_stream_master_node: ""
+
+# Defines weather the netdata node is acting as a proxy
+netdata_stream_proxy: false
 
 # Defines if Netdata should be uninstalled
 # Caution: This does not prompt for uninstall as the original script

--- a/templates/stream.conf.j2
+++ b/templates/stream.conf.j2
@@ -1,7 +1,7 @@
 # netdata stream configuration
 
-{% if netdata_stream_master_node == '' %}
-[{{ netdata_stream_api_key }}]
+{% if netdata_stream_master_node == '' or netdata_stream_proxy %}
+[{{ netdata_stream_receive_api_key }}]
     # enable/disable this API key
     enabled = yes
     
@@ -23,5 +23,5 @@
     destination = {{ netdata_stream_master_node }}
   
     # the API key to use
-    api key = {{ netdata_stream_api_key }}
+    api key = {{ netdata_stream_send_api_key }}
 {% endif %}


### PR DESCRIPTION
The current streaming template only allow the netdata node to be a sender or a receiver.
This PR adds a variable to make the host capable of both receiving and sending data, which is required for a host acting as a proxy between two different zone.