### PR TITLE
Netdata proxy ssl option

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -173,8 +173,14 @@ netdata_stream_receive_api_key: "{{ netdata_stream_api_key }}"
 # Defines Netdata master node and port (e.g. 127.0.0.1:19999)
 netdata_stream_master_node: ""
 
-# Defines weather the netdata node is acting as a proxy
+# Defines whether the netdata node is acting as a proxy
 netdata_stream_proxy: false
+
+# Defines client ssl configuration
+# netdata_client_ssl_options:
+#   ssl skip certificate verification: "yes"
+#   CAfile: /etc/ssl/certs/ca-certificates.crt
+netdata_client_ssl_options: {}
 
 # Defines if Netdata should be uninstalled
 # Caution: This does not prompt for uninstall as the original script

--- a/templates/stream.conf.j2
+++ b/templates/stream.conf.j2
@@ -22,7 +22,12 @@
       
     # the IP and PORT of the master
     destination = {{ netdata_stream_master_node }}
-  
+
+    # TLS client options
+{%  for ssl_option, ssl_value in netdata_client_ssl_options.items() %}
+    {{ ssl_option }} = {{ ssl_value }}
+{% endfor %}
+
     # the API key to use
     api key = {{ netdata_stream_send_api_key }}
 {% endif %}


### PR DESCRIPTION
At the moment we can't specify specific tls options (called ssl in netdata) for streaming clients.

This PR adds a dict to specify tls options. An example is provided in comment.