### PR TITLE
molecule: fix debian package installation error

### DIFF
--- a/molecule/debian10/molecule.yml
+++ b/molecule/debian10/molecule.yml
@@ -23,6 +23,7 @@ platforms:
 provisioner:
   name: ansible
   playbooks:
+    prepare: ../shared/prepare_debian.yml
     converge: ../shared/converge.yml
 verifier:
   name: ansible

--- a/molecule/debian8/molecule.yml
+++ b/molecule/debian8/molecule.yml
@@ -23,6 +23,7 @@ platforms:
 provisioner:
   name: ansible
   playbooks:
+    prepare: ../shared/prepare_debian.yml
     converge: ../shared/converge.yml
 verifier:
   name: ansible

--- a/molecule/debian9/molecule.yml
+++ b/molecule/debian9/molecule.yml
@@ -23,6 +23,7 @@ platforms:
 provisioner:
   name: ansible
   playbooks:
+    prepare: ../shared/prepare_debian.yml
     converge: ../shared/converge.yml
 verifier:
   name: ansible

--- a/molecule/shared/converge.yml
+++ b/molecule/shared/converge.yml
@@ -2,9 +2,8 @@
 - name: Converge
   hosts: all
   tasks:
-    - name: Include ansible-nodejs
-      include_role:
-        name: ansible-nodejs
     - name: Include ansible-netdata
       include_role:
         name: ansible-netdata
+  vars:
+    netdata_epel_setup: "{{ ansible_hostname == 'centos7' }}"

--- a/molecule/shared/prepare_debian.yml
+++ b/molecule/shared/prepare_debian.yml
@@ -1,0 +1,9 @@
+- name: Prepare
+  hosts: all
+  tasks:
+    - name: Install requisites
+      apt:
+        name: cron
+        state: present
+        update_cache: yes
+      become: true

--- a/molecule/ubuntu1604/molecule.yml
+++ b/molecule/ubuntu1604/molecule.yml
@@ -23,6 +23,7 @@ platforms:
 provisioner:
   name: ansible
   playbooks:
+    prepare: ../shared/prepare_debian.yml
     converge: ../shared/converge.yml
 verifier:
   name: ansible

--- a/molecule/ubuntu1804/molecule.yml
+++ b/molecule/ubuntu1804/molecule.yml
@@ -23,6 +23,7 @@ platforms:
 provisioner:
   name: ansible
   playbooks:
+    prepare: ../shared/prepare_debian.yml
     converge: ../shared/converge.yml
 verifier:
   name: ansible

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,2 +1,0 @@
----
-- src: https://www.github.com/mrlesmithjr/ansible-nodejs.git


### PR DESCRIPTION
Docker images for debian based used by  molecule come without reository data neither cron which is required later. This PR adds a prepare step to molecule for debian based images that basically install cron and do an `apt update` to fetch repository metadata.

The node role requirements doesn't seems to be necessary so I removed it. 